### PR TITLE
feat: configurable LibreOffice previews (Rails 7) + robust PDF→PNG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ To preview files this plugin converts the previewed file content to either
 The appropriate conversion type(s) is/are up to the plugin developer. The available conversion option can be chosen on the plugin configuration page. 
 The plugin was developed with thread safety in mind. With caching enabled, it should stand even higher loads.
 
+## Requirements
+- LibreOffice (soffice binary)
+- Java runtime (if required)
+- poppler-utils (pdftoppm) or ImageMagick
+
+## Compatibility
+- Redmine 6.x
+- Rails 7
+
+> For Nginx, serve /plugin_assets directly and add MIME types for .mjs and .wasm if an external JS viewer is used.
+
+## Quick test
+1. Upload a .docx file.
+2. Preview it in Redmine.
+3. If it fails, check the Redmine logs for the LibreOffice command.
+
+## Configuration
+
+From *Administration → Plugins → Redmine More Previews*, you can configure:
+
+- Enable previews for Office files
+- Paths and environment overrides for LibreOffice
+- Preferred PDF→Image tool and density
+- Skip PDFs to let another plugin handle them
+
 Currently, there exist the following plugins:
 
 ---

--- a/app/views/settings/redmine_more_previews/_settings.html.erb
+++ b/app/views/settings/redmine_more_previews/_settings.html.erb
@@ -49,7 +49,7 @@
 </fieldset>
 
 <fieldset class="box tabular settings"><legend><%= l(:label_debug) %></legend>
-  <p>  
+  <p>
     <label><%= l(:label_debug)  %></label>
       <%= check_box_tag 'settings[debug]', 1, (settings["debug"] == "1" ) %>
   </p>
@@ -59,6 +59,66 @@
     <span id="help_redmine_more_previews_debug" class="info" style="display: none;">
       <em class="info"><%= l(:text_help_redmine_more_previews_debug) %></em>
     </span>
+  </p>
+</fieldset>
+
+<fieldset class="box tabular settings"><legend>LibreOffice</legend>
+  <p>
+    <label>Enable previews for Office files</label>
+      <%= check_box_tag 'settings[enable_office]', 1, (settings["enable_office"] != "0" ) %>
+  </p>
+  <p>
+    <label>LibreOffice binary path</label>
+      <%= text_field_tag 'settings[lo_bin]', settings["lo_bin"] %>
+  </p>
+  <p>
+    <label>LO UserInstallation dir</label>
+      <%= text_field_tag 'settings[lo_profile]', settings["lo_profile"] %>
+  </p>
+  <p>
+    <label>HOME override for converter</label>
+      <%= text_field_tag 'settings[home_override]', settings["home_override"] %>
+  </p>
+  <p>
+    <label>PATH override</label>
+      <%= text_field_tag 'settings[path_override]', settings["path_override"] %>
+  </p>
+  <p>
+    <label>TMPDIR</label>
+      <%= text_field_tag 'settings[tmpdir]', settings["tmpdir"] %>
+  </p>
+  <p>
+    <label>XDG_RUNTIME_DIR</label>
+      <%= text_field_tag 'settings[xdg_runtime]', settings["xdg_runtime"] %>
+  </p>
+  <p>
+    <label>Convert timeout (seconds)</label>
+      <%= number_field_tag 'settings[convert_timeout]', settings["convert_timeout"], :min => 1 %>
+  </p>
+  <p>
+    <label>Office → PDF density for image</label>
+      <%= number_field_tag 'settings[pdf_density]', settings["pdf_density"], :min => 1 %>
+  </p>
+  <p>
+    <label>Preferred PDF→Image tool</label>
+      <%= select_tag 'settings[pdf_tool]', options_for_select([['pdftoppm','pdftoppm'],['convert','convert']], settings["pdf_tool"]) %>
+  </p>
+  <p>
+    <label>Skip PDFs (handled by external PDF viewer plugin)</label>
+      <%= check_box_tag 'settings[skip_pdfs]', 1, (settings["skip_pdfs"] != "0" ) %>
+  </p>
+  <hr>
+  <p>
+    <% lo_path = settings["lo_bin"].to_s.empty? ? '/usr/lib/libreoffice/program/soffice' : settings["lo_bin"] %>
+    LibreOffice: <span class="icon-only <%= File.exist?(lo_path) ? 'icon-ok' : 'icon-error' %>"></span> <code><%= lo_path %></code>
+  </p>
+  <p>
+    <% pdftoppm_path = `which pdftoppm 2>/dev/null`.strip %>
+    pdftoppm: <span class="icon-only <%= pdftoppm_path.empty? ? 'icon-error' : 'icon-ok' %>"></span>
+  </p>
+  <p>
+    <% convert_path = `which convert 2>/dev/null`.strip %>
+    convert: <span class="icon-only <%= convert_path.empty? ? 'icon-error' : 'icon-ok' %>"></span>
   </p>
 </fieldset>
 

--- a/converters/libre/lib/libre.rb
+++ b/converters/libre/lib/libre.rb
@@ -19,36 +19,128 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+require 'open3'
+require 'fileutils'
+
 class Libre < RedmineMorePreviews::Conversion
 
-  #---------------------------------------------------------------------------------
-  # constants
-  #---------------------------------------------------------------------------------
-  LIBRE_OFFICE_BIN = 'soffice'.freeze
-  
+  def plugin_settings
+    @plugin_settings ||= ::Setting['plugin_redmine_more_previews'].to_h
+  end
+
+  def libreoffice_bin
+    plugin_settings['lo_bin'].presence || '/usr/lib/libreoffice/program/soffice'
+  end
+
+  def profile_path
+    plugin_settings['lo_profile'].presence || '/tmp/libreoffice_profile'
+  end
+
+  def lo_env
+    {
+      'HOME'            => plugin_settings['home_override'].presence || '/var/www',
+      'PATH'            => plugin_settings['path_override'].presence || '/usr/bin:/bin',
+      'TMPDIR'          => plugin_settings['tmpdir'].presence || '/tmp',
+      'XDG_RUNTIME_DIR' => plugin_settings['xdg_runtime'].presence || '/tmp',
+      'LANG'            => 'en_US.UTF-8'
+    }
+  end
+
+  def lo_timeout
+    (plugin_settings['convert_timeout'] || 60).to_i
+  end
+
+  def pdf_density
+    (plugin_settings['pdf_density'] || 150).to_i
+  end
+
+  def pdf_tool
+    plugin_settings['pdf_tool'].presence || 'pdftoppm'
+  end
+
   #---------------------------------------------------------------------------------
   # check: is LibreOffice available?
   #---------------------------------------------------------------------------------
   def status
-    s = run [LIBRE_OFFICE_BIN, "--version"]
-    [:text_libre_office_available, s[2] == 0 ]
+    _stdout, _stderr, status = Open3.capture3(lo_env, libreoffice_bin, '--version')
+    [:text_libre_office_available, status.success?]
+  rescue Errno::ENOENT
+    [:text_libre_office_available, false]
   end
-  
+
   def convert
-  
-    Dir.mktmpdir do |tdir| 
-    user_installation = File.join(tdir, "user_installation")
-    command(cd + join + soffice( source, user_installation ) + join + move(thisdir(outfile)) )
+    FileUtils.mkdir_p(profile_path)
+    profile = "file://#{profile_path}"
+
+    lo_format = preview_format
+    if %w[png jpg].include?(preview_format)
+      lo_format = 'pdf'
     end
-    
-  end #def
-  
-  def soffice( src, user_installation )
-    if Redmine::Platform.mswin?
-    "#{LIBRE_OFFICE_BIN} --headless --convert-to #{preview_format} --outdir #{shell_quote tmpdir} #{shell_quote src}"
-    else
-    "#{LIBRE_OFFICE_BIN} --headless --convert-to #{preview_format} --outdir #{shell_quote tmpdir} -env:UserInstallation=file://#{user_installation} #{shell_quote src}"
+
+    cmd = [
+      libreoffice_bin, '--headless',
+      "-env:UserInstallation=#{profile}",
+      '--convert-to', lo_format,
+      source,
+      '--outdir', tmpdir
+    ]
+
+    stdout_str = stderr_str = ''
+    status = nil
+    Open3.popen3(lo_env, *cmd) do |stdin, stdout, stderr, wait_thr|
+      stdin.close
+      if wait_thr.join(lo_timeout).nil?
+        Process.kill('KILL', wait_thr.pid) rescue nil
+        stdout_str = stdout.read
+        stderr_str = stderr.read
+        Rails.logger.error("[redmine_more_previews][LO] exit=timeout cmd='#{cmd.join(' ')}' stdout='#{stdout_str}' stderr='#{stderr_str}'")
+        raise "LibreOffice conversion failed (timeout)"
+      else
+        stdout_str = stdout.read
+        stderr_str = stderr.read
+        status = wait_thr.value
+      end
     end
+    unless status&.success?
+      Rails.logger.error("[redmine_more_previews][LO] exit=#{status&.exitstatus} cmd='#{cmd.join(' ')}' stdout='#{stdout_str}' stderr='#{stderr_str}'")
+      raise "LibreOffice conversion failed (exit #{status&.exitstatus})"
+    end
+
+    if %w[png jpg].include?(preview_format)
+      base = File.basename(source, File.extname(source))
+      pdf_file = File.join(tmpdir, "#{base}.pdf")
+      out_file = File.join(tmpdir, outfile)
+      tool = pdf_tool
+      if tool == 'pdftoppm'
+        tool_path = `which pdftoppm 2>/dev/null`.strip
+        tool = 'convert' if tool_path.empty?
+      end
+      if tool == 'pdftoppm'
+        cmd2 = [
+          'pdftoppm',
+          "-#{preview_format == 'jpg' ? 'jpeg' : 'png'}",
+          '-singlefile',
+          '-r', pdf_density.to_s,
+          pdf_file,
+          File.join(tmpdir, base)
+        ]
+        stdout_str, stderr_str, status = Open3.capture3(lo_env, *cmd2)
+      else
+        cmd2 = [
+          'convert',
+          '-density', pdf_density.to_s,
+          "#{pdf_file}[0]",
+          out_file
+        ]
+        stdout_str, stderr_str, status = Open3.capture3(lo_env, *cmd2)
+      end
+      unless status.success?
+        Rails.logger.error("[redmine_more_previews][PDF] exit=#{status.exitstatus} cmd='#{cmd2.join(' ')}' stdout='#{stdout_str}' stderr='#{stderr_str}'")
+        raise "PDF to image conversion failed (exit #{status.exitstatus})"
+      end
+    end
+
+    FileUtils.mv(File.join(tmpdir, outfile), tmptarget)
   end #def
-  
+
 end #class

--- a/init.rb
+++ b/init.rb
@@ -118,6 +118,7 @@
 #       - fixed long standing issue with links in zippy's inline zip file content tables
 # 5.0.9 
 #       - runs on Redmine 6.x
+require_relative "lib/compat/unloadable"
 #-----------------------------------------------------------------------------------------
 # Register plugin
 #-----------------------------------------------------------------------------------------
@@ -131,10 +132,22 @@ Redmine::Plugin.register :redmine_more_previews do
   
   requires_redmine(:version_or_higher => '4')
   
-  settings :default => {'embedding'      => '0',  # use <object><embed>-tag or <iframe>-tag
+  settings :default => {
+                        'embedding'      => '0',  # use <object><embed>-tag or <iframe>-tag
                         'cache_previews' => '1',  # yes, cache previews
                         'debug'          => '0',  # no, do not debug
                         'absolute'       => '0',  # no, use relative paths for iFrame- and embed-tags
+                        'enable_office'  => '1',
+                        'lo_bin'         => '/usr/lib/libreoffice/program/soffice',
+                        'lo_profile'     => '/tmp/libreoffice_profile',
+                        'home_override'  => '/var/www',
+                        'path_override'  => '/usr/bin:/bin',
+                        'tmpdir'         => '/tmp',
+                        'xdg_runtime'    => '/tmp',
+                        'convert_timeout'=> '60',
+                        'pdf_density'    => '150',
+                        'pdf_tool'       => 'pdftoppm',
+                        'skip_pdfs'      => '1'
                        },
            :partial => 'settings/redmine_more_previews/settings'
            

--- a/lib/compat/unloadable.rb
+++ b/lib/compat/unloadable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+module Kernel
+  def unloadable(*); end
+end
+module Compat
+  module Unloadable; end
+end

--- a/lib/redmine_more_previews/converter.rb
+++ b/lib/redmine_more_previews/converter.rb
@@ -214,6 +214,13 @@ module RedmineMorePreviews
     ######################################################################################
     def self.convertible?( filename )
       ext = File.extname( filename ).gsub(/\A\./,"").downcase
+      if ext == 'pdf'
+        return false if ::Setting['plugin_redmine_more_previews']['skip_pdfs'].to_s != '0'
+      end
+      if ::Setting['plugin_redmine_more_previews']['enable_office'].to_s == '0'
+        libre_exts = registered_converters.dig(:libre)&.mime_types&.keys&.map(&:to_s) || []
+        return false if libre_exts.include?(ext)
+      end
       active_extensions.include?(ext)
     end #def
     
@@ -282,8 +289,9 @@ module RedmineMorePreviews
     end #def
     
     def self.active_converters
-      select_active( configured_converters ).
-      select{|key, val| installed?(key)}
+      conv = select_active( configured_converters )
+      conv.delete('libre') if ::Setting['plugin_redmine_more_previews']['enable_office'].to_s == '0'
+      conv.select{|key, val| installed?(key)}
     end #def
     
     def self.active_mime_types

--- a/lib/tasks/redmine_more_previews.rake
+++ b/lib/tasks/redmine_more_previews.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'fileutils'
+namespace :redmine_more_previews do
+  desc 'Diagnose redmine_more_previews environment'
+  task :diagnose => :environment do
+    settings = Setting.plugin_redmine_more_previews
+    puts "Redmine version: #{Redmine::VERSION.to_s}"
+    puts "Ruby version: #{RUBY_VERSION}"
+    env = {
+      'HOME'            => settings['home_override'] || '/var/www',
+      'PATH'            => settings['path_override'] || '/usr/bin:/bin',
+      'TMPDIR'          => settings['tmpdir'] || '/tmp',
+      'XDG_RUNTIME_DIR' => settings['xdg_runtime'] || '/tmp',
+      'LANG'            => 'en_US.UTF-8'
+    }
+    soffice = settings['lo_bin'] || '/usr/lib/libreoffice/program/soffice'
+    begin
+      stdout, stderr, status = Open3.capture3(env, soffice, '--version')
+      puts "soffice: #{status.success? ? stdout.strip : stderr.strip}"
+    rescue => e
+      puts "soffice: error (#{e.message})"
+    end
+    %w[pdftoppm convert].each do |bin|
+      path = `which #{bin} 2>/dev/null`.strip
+      puts "#{bin}: #{path.empty? ? 'not found' : path}"
+    end
+    profile = settings['lo_profile'] || '/tmp/libreoffice_profile'
+    exist = File.directory?(profile)
+    writable = begin
+      FileUtils.mkdir_p(profile)
+      File.writable?(profile)
+    rescue
+      false
+    end
+    puts "UserInstallation dir: #{profile} (exists=#{exist} writable=#{writable})"
+  end
+end
+


### PR DESCRIPTION
## Summary
- add configurable environment for LibreOffice conversions with timeout and PDF→image pipeline
- expose plugin settings for LibreOffice path, profile dir, env overrides, density, and PDF skipping
- provide diagnostic rake task and updated documentation

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'marcel' in locally installed gems)*
- `bundle exec rake redmine:plugins:migrate RAILS_ENV=production` *(fails: Could not find gem 'marcel' in locally installed gems)*
- `bundle exec rake redmine_more_previews:diagnose` *(fails: Could not find gem 'marcel' in locally installed gems)*
- `ruby -e 'require "open3"; env={"HOME"=>"/var/www","PATH"=>"/usr/bin:/bin","TMPDIR"=>"/tmp","XDG_RUNTIME_DIR"=>"/tmp","LANG"=>"en_US.UTF-8"}; stdout,stderr,status = Open3.capture3(env, "/usr/lib/libreoffice/program/soffice","--version"); puts stdout; warn stderr; puts status.exitstatus'` *(fails: No such file or directory - /usr/lib/libreoffice/program/soffice)*

------
https://chatgpt.com/codex/tasks/task_e_68963abb7a44832f9da96fcf868a836b